### PR TITLE
Misc: add inline comment to initialize `accounts` map

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,6 +8,8 @@
 // ==/UserScript==
 
 // Add your AWS account information below
+// You can use the following command to populate an initial map without colors:
+// $ aws organizations list-accounts | jq -r '.Accounts | map(.Id + ": [\"" + .Name + "\"],")[]'
 const accounts = {
   786908262739: ["root"],
   264850291039: ["production", "red"],


### PR DESCRIPTION
This simply adds an inline comment with a command that makes it easier to initialize this `accounts` map, especially if you have a lot of accounts in your organization.

Great script btw, thanks.